### PR TITLE
apply pending upstream patch for coreos/bbolt to address runtime panic

### DIFF
--- a/vendor/github.com/coreos/bbolt/tx.go
+++ b/vendor/github.com/coreos/bbolt/tx.go
@@ -264,7 +264,14 @@ func (tx *Tx) rollback() {
 	}
 	if tx.writable {
 		tx.db.freelist.rollback(tx.meta.txid)
-		tx.db.freelist.reload(tx.db.page(tx.db.meta().freelist))
+		if !tx.db.hasSyncedFreelist() {
+			// Reconstruct free page list by scanning the DB to get the whole free page list.
+			// Note: scaning the whole db is heavy if your db size is large in NoSyncFreeList mode.
+			tx.db.freelist.noSyncReload(tx.db.freepages())
+		} else {
+			// Read free page list from freelist page.
+			tx.db.freelist.reload(tx.db.page(tx.db.meta().freelist))
+		}
 	}
 	tx.close()
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -14,10 +14,11 @@
 			"revisionTime": "2018-03-21T16:47:47Z"
 		},
 		{
-			"checksumSHA1": "pQ9Erdp0Jv+Q8Q2pGi+4yxXSUi4=",
+			"checksumSHA1": "VH2UsbFl/s2cy5NYQOUqffVIUjQ=",
+			"origin": "github.com/WIZARD-CXY/bbolt",
 			"path": "github.com/coreos/bbolt",
-			"revision": "63597a96ec0ad9e6d43c3fc81e809909e0237461",
-			"revisionTime": "2019-01-28T18:11:30Z"
+			"revision": "746c2799f99dc9dc2942985b256fd92b7ae4d6cf",
+			"revisionTime": "2019-03-13T03:34:15Z"
 		},
 		{
 			"checksumSHA1": "sFGNqtSE3WlMiyT+JkVaW2OzstM=",


### PR DESCRIPTION
There is a pending PR upstream https://github.com/etcd-io/bbolt/pull/153 in etcd-io/bbolt (coreos/bbolt) to fix a runtime panic that we've observed.

This pr vendors that patch pending upstream.

We will update this vendor dependency to the officially released version once it is merged up stream.
