### PR TITLE
Improve joining existing clusters

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -327,7 +327,7 @@ func DefaultGatewayConfig() *GatewayConfig {
 		EtcdServerStartTimeout:        pointer.Duration(time.Second * 90),
 		UnhealthyMemberTTL:            pointer.Duration(embetcd.DefaultUnhealthyTTL),
 		RemoveMemberTimeout:           pointer.Duration(time.Second),
-		EtcdStartupGracePeriod:        pointer.Duration(embetcd.DefaultStartUpGracePeriod),
+		EtcdStartupGracePeriod:        pointer.Duration(time.Second * 120),
 		EtcdDialTimeout:               pointer.Duration(embetcd.DefaultDialTimeout),
 		EtcdClusterCleanUpInterval:    pointer.Duration(embetcd.DefaultCleanUpInterval),
 		EtcdAutoSyncInterval:          pointer.Duration(embetcd.DefaultAutoSyncInterval),

--- a/config/config.go
+++ b/config/config.go
@@ -270,6 +270,11 @@ func (p *GatewayConfig) ToEtcdConfig() *embetcd.Config {
 		}
 	}
 
+	// set the cluster name as the initial cluster token
+	if p.ClusterName != nil {
+		etcdCfg.InitialClusterToken = *p.ClusterName
+	}
+
 	copyEtcdDurations(p, etcdCfg)
 	copyEtcdURLs(p, etcdCfg)
 	copyEtcdFileConfigs(p, etcdCfg)

--- a/gobuild.toml
+++ b/gobuild.toml
@@ -2,7 +2,7 @@
   ignoreDirs = [".git", "vendor"]
   duplLimit = "300"
   testCoverage = 100.0
-  testFlags = ["-covermode", "atomic", "-timeout", "60s", "-cpu", "4", "-parallel", "8"]
+  testFlags = ["-covermode", "atomic", "-timeout", "120s", "-cpu", "4", "-parallel", "8"]
 
 [metalinter]
   [metalinter.vars]

--- a/vendor/github.com/signalfx/embetcd/embetcd/common.go
+++ b/vendor/github.com/signalfx/embetcd/embetcd/common.go
@@ -78,3 +78,14 @@ func RevokeLease(ctx context.Context, client *Client, lease *cli.LeaseGrantRespo
 		client.Revoke(ctx, lease.ID)
 	}
 }
+
+// StringIsInStringSlice returns true if the given string is in the slice of strings
+func StringIsInStringSlice(s string, strs []string) (resp bool) {
+	for _, i := range strs {
+		if s == i {
+			resp = true
+			break
+		}
+	}
+	return
+}

--- a/vendor/github.com/signalfx/embetcd/embetcd/config.go
+++ b/vendor/github.com/signalfx/embetcd/embetcd/config.go
@@ -2,7 +2,6 @@ package embetcd
 
 import (
 	"context"
-	"crypto/tls"
 	"time"
 
 	cli "github.com/coreos/etcd/clientv3"
@@ -31,7 +30,6 @@ func (c *Config) GetClientFromConfig(ctx context.Context) (*Client, error) {
 	return NewClient(cli.Config{
 		Endpoints:        c.InitialCluster,
 		DialTimeout:      DurationOrDefault(c.DialTimeout, DefaultDialTimeout),
-		TLS:              &tls.Config{InsecureSkipVerify: true}, // insecure for now
 		AutoSyncInterval: DurationOrDefault(c.AutoSyncInterval, DefaultAutoSyncInterval),
 		Context:          ctx, // pass in the context so the temp client closes with a cancelled context
 	})

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1066,12 +1066,12 @@
 			"revisionTime": "2019-02-22T19:39:49Z"
 		},
 		{
-			"checksumSHA1": "r9+PgRAjGoqJVZxIyDu84e2qWoE=",
+			"checksumSHA1": "y7F7c5fLaVPVlxsX6Zfpz+Or86Q=",
 			"path": "github.com/signalfx/embetcd/embetcd",
-			"revision": "bac7a59c30297840abee29adeccdb7f75d89fd35",
-			"revisionTime": "2019-04-17T22:36:50Z",
-			"version": "v0.0.7",
-			"versionExact": "v0.0.7"
+			"revision": "3f369f70e26472d97b7f761a9c19103883199c73",
+			"revisionTime": "2019-04-29T17:39:57Z",
+			"version": "v0.0.8",
+			"versionExact": "v0.0.8"
 		},
 		{
 			"path": "github.com/signalfx/gateway/cluster/etcd/etcdutil",


### PR DESCRIPTION
* improve joining existing clusters by updating embetcd in vendor deps
* extend the default graceful startup timeout
* set etcd initial cluster token
* extend go test timeout