### PR TITLE
Removing logging config to avoid leaking environment secrets

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -458,10 +458,20 @@ func (p *GatewayConfig) String() string {
 	return "<config object>"
 }
 
-// Var returns the gateway config itself as an expvar
+// Var returns a clone of the gateway config with secrets being redacted
 func (p *GatewayConfig) Var() expvar.Var {
 	return expvar.Func(func() interface{} {
-		return p
+		redacted := "redacted"
+		safeExport := p
+		for _, settings := range safeExport.ForwardTo {
+			if settings.DefaultAuthToken != nil {
+				settings.DefaultAuthToken = &redacted
+			}
+			if settings.AuthTokenEnvVar != nil {
+				settings.AuthTokenEnvVar = &redacted
+			}
+		}
+		return safeExport
 	})
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -467,9 +467,6 @@ func (p *GatewayConfig) Var() expvar.Var {
 			if settings.DefaultAuthToken != nil {
 				settings.DefaultAuthToken = &redacted
 			}
-			if settings.AuthTokenEnvVar != nil {
-				settings.AuthTokenEnvVar = &redacted
-			}
 		}
 		return safeExport
 	})

--- a/main.go
+++ b/main.go
@@ -326,6 +326,7 @@ func (p *gateway) setupDebugServer(conf *config.GatewayConfig, logger log.Logger
 	})
 	p.debugServer.Mux.Handle("/debug/dims", &p.debugSink)
 
+	p.debugServer.Exp2.Exported["config"] = conf.Var()
 	p.debugServer.Exp2.Exported["datapoints"] = scheduler.Var()
 	p.debugServer.Exp2.Exported["goruntime"] = expvar.Func(func() interface{} {
 		return runtime.Version()

--- a/main.go
+++ b/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"expvar"
 	"flag"
 	"fmt"
@@ -901,10 +900,6 @@ func loadConfig(configFilePath string, logger log.Logger) (*config.GatewayConfig
 	// add flag values to the loadedConfig.  This overrides any values in the config file with runtime flags.
 	flags.addFlagsToConfig(loadedConfig)
 
-	// log the config that we loaded
-	if _, err = json.Marshal(loadedConfig); err != nil {
-		return nil, err
-	}
 	logger.Log("config loaded")
 	return loadedConfig, nil
 }


### PR DESCRIPTION
- The environment is loaded and printed out to stdout, this can not
happen in some environments and shouldn't be encouraged as good
practice.
- There is a few places the token is printed out in plain text, I had
removed such log lines