### PR TITLE
Updated link to repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Events Ingest and Trace Ingest APIs.
 ## Usage and Configuration
 
 Please refer to the usage and configuration documentation located
-[here](https://github.com/signalfx/integrations/tree/master/gateway) for more
+[here](https://github.com/signalfx/integrations/tree/release/gateway) for more
 information on operating the SignalFx Gateway.
 
 ## Development


### PR DESCRIPTION
To match what's in the docs (https://docs.signalfx.com/en/latest/integrations/integrations-reference/integrations.signalfx.gateway.html) and to address the jumping-around-confusion mentioned here https://signalfuse.atlassian.net/browse/DOCS-706