### PR TITLE
Added a new SetupJSONByNPaths function to protocol/signalfx package

### DIFF
--- a/protocol/signalfx/signalfxlistener.go
+++ b/protocol/signalfx/signalfxlistener.go
@@ -334,6 +334,14 @@ func SetupJSONByPaths(r *mux.Router, handler http.Handler, endpoint string) {
 	r.Path(endpoint).Methods("POST").Handler(handler)
 }
 
+// SetupJSONByPathsN tells the router which paths the given handler (which should handle the given
+// endpoint) should see
+func SetupJSONByPathsN(r *mux.Router, handler http.Handler, endpoints ...string) {
+	for _, endpoint := range endpoints {
+		SetupJSONByPaths(r, handler, endpoint)
+	}
+}
+
 func setupCollectd(ctx context.Context, r *mux.Router, sink dpsink.Sink, debugContext *web.HeaderCtxFlag, httpChain web.NextConstructor, logger log.Logger, counter *dpsink.Counter) sfxclient.Collector {
 	finalSink := dpsink.FromChain(sink, dpsink.NextWrap(counter))
 	decoder := collectd.JSONDecoder{

--- a/protocol/signalfx/trace_zipkin.go
+++ b/protocol/signalfx/trace_zipkin.go
@@ -22,6 +22,10 @@ import (
 const (
 	// DefaultTracePathV1 is the default listen path
 	DefaultTracePathV1 = "/v1/trace"
+	// ZipkinTracePathV1 adds /api/v1/spans endpoint
+	ZipkinTracePathV1 = "/api/v1/spans"
+	// ZipkinTracePathV2 adds /api/vw/spans endpoint
+	ZipkinTracePathV2 = "/api/v2/spans"
 	// ZipkinV1 is a constant used for protocol naming
 	ZipkinV1 = "zipkin_json_v1"
 )
@@ -595,6 +599,6 @@ func setupJSONTraceV1(ctx context.Context, r *mux.Router, sink Sink, logger log.
 	handler, st := SetupChain(ctx, sink, ZipkinV1, func(s Sink) ErrorReader {
 		return &JSONTraceDecoderV1{Logger: logger, Sink: sink}
 	}, httpChain, logger, counter)
-	SetupJSONByPaths(r, handler, DefaultTracePathV1)
+	SetupJSONByPathsN(r, handler, DefaultTracePathV1, ZipkinTracePathV1, ZipkinTracePathV2)
 	return st
 }


### PR DESCRIPTION
Added the new function allow adding multiple paths to the same chain
instead of having to setup multiple ones.

We could change the existing SetupJSONByPaths function to accept
multiple paths. I added new function since it is public and might be used by packages
we don't know about.