### PR TITLE
Skip invalid datapoints in carbon listener

### DIFF
--- a/protocol/carbon/carbon.go
+++ b/protocol/carbon/carbon.go
@@ -38,7 +38,7 @@ func NewCarbonDatapoint(line string, metricDeconstructor metricdeconstructor.Met
 	originalMetricName := parts[0]
 	metricName, mtype, dimensions, err := metricDeconstructor.Parse(originalMetricName)
 
-	if err == metricdeconstructor.SkipMetricErr {
+	if err == metricdeconstructor.ErrSkipMetric {
 		return nil, nil
 	}
 	if err != nil {

--- a/protocol/carbon/carbon.go
+++ b/protocol/carbon/carbon.go
@@ -37,6 +37,10 @@ func NewCarbonDatapoint(line string, metricDeconstructor metricdeconstructor.Met
 	}
 	originalMetricName := parts[0]
 	metricName, mtype, dimensions, err := metricDeconstructor.Parse(originalMetricName)
+
+	if err == metricdeconstructor.SkipMetricErr {
+		return nil, nil
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/protocol/carbon/carbonlistener.go
+++ b/protocol/carbon/carbonlistener.go
@@ -43,6 +43,7 @@ var _ protocol.Listener = &Listener{}
 
 type listenerStats struct {
 	totalDatapoints     int64
+	skippedDatapoints   int64
 	idleTimeouts        int64
 	retriedListenErrors int64
 	totalEOFCloses      int64
@@ -119,6 +120,7 @@ func (listener *Listener) handleUDPConnection(ctx context.Context, addr *net.UDP
 				}
 
 				if dp == nil {
+					atomic.AddInt64(&listener.stats.skippedDatapoints, 1)
 					continue
 				}
 
@@ -156,6 +158,7 @@ func (listener *Listener) handleTCPConnection(ctx context.Context, conn carbonLi
 				continue
 			}
 			if dp == nil {
+				atomic.AddInt64(&listener.stats.skippedDatapoints, 1)
 				continue
 			}
 			log.IfErr(connLogger, listener.sink.AddDatapoints(ctx, []*datapoint.Datapoint{dp}))

--- a/protocol/carbon/carbonlistener_test.go
+++ b/protocol/carbon/carbonlistener_test.go
@@ -73,10 +73,6 @@ func TestCarbonForwarderNormal(t *testing.T) {
 		l, err := net.Listen("tcp", "127.0.0.1:0")
 		So(err, ShouldBeNil)
 
-		Convey("Using nil deconstructor skips message", func() {
-
-		})
-
 		Convey("Invalid regexes should cause an error", func() {
 			forwardConfig := &ForwarderConfig{
 				Port:    pointer.Uint16(nettest.TCPPort(l)),
@@ -279,7 +275,7 @@ func TestCarbonListenerNormalTCP(t *testing.T) {
 		})
 	})
 
-	Convey("using nil deconstrutor skips message", t, func() {
+	Convey("using nil deconstructor skips message", t, func() {
 		listenFrom := &ListenerConfig{
 			ListenAddr:          pointer.String("127.0.0.1:0"),
 			MetricDeconstructor: &metricdeconstructor.NilDeconstructor{},
@@ -298,6 +294,8 @@ func TestCarbonListenerNormalTCP(t *testing.T) {
 		for atomic.LoadInt64(&listener.stats.skippedDatapoints) != 1 {
 			time.Sleep(time.Millisecond)
 		}
+
+		So(listener.Close(), ShouldBeNil)
 	})
 }
 
@@ -407,7 +405,7 @@ func TestCarbonListenerNormalUDP(t *testing.T) {
 		})
 	})
 
-	Convey("using nil deconstrutor skips message", t, func() {
+	Convey("using nil deconstructor skips message", t, func() {
 		listenFrom := &ListenerConfig{
 			ListenAddr:          pointer.String("127.0.0.1:0"),
 			Protocol:            pointer.String("udp"),
@@ -425,6 +423,8 @@ func TestCarbonListenerNormalUDP(t *testing.T) {
 		for atomic.LoadInt64(&listener.stats.skippedDatapoints) != 1 {
 			time.Sleep(time.Millisecond)
 		}
+
+		So(listener.Close(), ShouldBeNil)
 	})
 }
 

--- a/protocol/carbon/metricdeconstructor/configurabledelimiterdeconstructor_test.go
+++ b/protocol/carbon/metricdeconstructor/configurabledelimiterdeconstructor_test.go
@@ -254,7 +254,7 @@ func TestFallbackNil(t *testing.T) {
 			_, _, _, err = m.Parse("one.two.three.four.five.six.seven")
 			Convey("should parse giving an error", func() {
 				So(err, ShouldNotBeNil)
-				So(err.Error(), ShouldEqual, "nilDeconstructor always returns an error")
+				So(err, ShouldEqual, SkipMetricErr)
 			})
 		})
 	})

--- a/protocol/carbon/metricdeconstructor/configurabledelimiterdeconstructor_test.go
+++ b/protocol/carbon/metricdeconstructor/configurabledelimiterdeconstructor_test.go
@@ -254,7 +254,7 @@ func TestFallbackNil(t *testing.T) {
 			_, _, _, err = m.Parse("one.two.three.four.five.six.seven")
 			Convey("should parse giving an error", func() {
 				So(err, ShouldNotBeNil)
-				So(err, ShouldEqual, SkipMetricErr)
+				So(err, ShouldEqual, ErrSkipMetric)
 			})
 		})
 	})

--- a/protocol/carbon/metricdeconstructor/configurableregexdeconstructor_test.go
+++ b/protocol/carbon/metricdeconstructor/configurableregexdeconstructor_test.go
@@ -158,7 +158,7 @@ func TestRegexFallback(t *testing.T) {
 			_, _, _, err = m.Parse("one.two.three.four.five.six.seven")
 			Convey("should parse giving an error", func() {
 				So(err, ShouldNotBeNil)
-				So(err.Error(), ShouldEqual, "nilDeconstructor always returns an error")
+				So(err, ShouldEqual, SkipMetricErr)
 			})
 		})
 	})

--- a/protocol/carbon/metricdeconstructor/configurableregexdeconstructor_test.go
+++ b/protocol/carbon/metricdeconstructor/configurableregexdeconstructor_test.go
@@ -158,7 +158,7 @@ func TestRegexFallback(t *testing.T) {
 			_, _, _, err = m.Parse("one.two.three.four.five.six.seven")
 			Convey("should parse giving an error", func() {
 				So(err, ShouldNotBeNil)
-				So(err, ShouldEqual, SkipMetricErr)
+				So(err, ShouldEqual, ErrSkipMetric)
 			})
 		})
 	})

--- a/protocol/carbon/metricdeconstructor/nildeconstructor.go
+++ b/protocol/carbon/metricdeconstructor/nildeconstructor.go
@@ -5,13 +5,15 @@ import (
 	"github.com/signalfx/golib/datapoint"
 )
 
-var SkipMetricErr = errors.New("skip metric")
+// ErrSkipMetric is returned when parsing to indicate skipping
+var ErrSkipMetric = errors.New("skip metric")
 
+// NilDeconstructor is a parser that always skips a metric
 type NilDeconstructor struct{}
 
 // Parse always returns an error
 func (m *NilDeconstructor) Parse(originalMetric string) (string, datapoint.MetricType, map[string]string, error) {
-	return "", datapoint.Gauge, nil, SkipMetricErr
+	return "", datapoint.Gauge, nil, ErrSkipMetric
 }
 
 func nilLoader(options string) (MetricDeconstructor, error) {

--- a/protocol/carbon/metricdeconstructor/nildeconstructor.go
+++ b/protocol/carbon/metricdeconstructor/nildeconstructor.go
@@ -7,13 +7,13 @@ import (
 
 var SkipMetricErr = errors.New("skip metric")
 
-type nilDeconstructor struct{}
+type NilDeconstructor struct{}
 
 // Parse always returns an error
-func (m *nilDeconstructor) Parse(originalMetric string) (string, datapoint.MetricType, map[string]string, error) {
+func (m *NilDeconstructor) Parse(originalMetric string) (string, datapoint.MetricType, map[string]string, error) {
 	return "", datapoint.Gauge, nil, SkipMetricErr
 }
 
 func nilLoader(options string) (MetricDeconstructor, error) {
-	return &nilDeconstructor{}, nil
+	return &NilDeconstructor{}, nil
 }

--- a/protocol/carbon/metricdeconstructor/nildeconstructor.go
+++ b/protocol/carbon/metricdeconstructor/nildeconstructor.go
@@ -2,15 +2,16 @@ package metricdeconstructor
 
 import (
 	"errors"
-
 	"github.com/signalfx/golib/datapoint"
 )
+
+var SkipMetricErr = errors.New("skip metric")
 
 type nilDeconstructor struct{}
 
 // Parse always returns an error
 func (m *nilDeconstructor) Parse(originalMetric string) (string, datapoint.MetricType, map[string]string, error) {
-	return "", datapoint.Gauge, nil, errors.New("nilDeconstructor always returns an error")
+	return "", datapoint.Gauge, nil, SkipMetricErr
 }
 
 func nilLoader(options string) (MetricDeconstructor, error) {


### PR DESCRIPTION
The carbon listener (UDP and TCP) would drop the message/connection if a single
incoming datapoint was invalid instead of ignoring it and continuing.