### PR TITLE
Fix redistribution of spans wrt additional forwarders

### DIFF
--- a/main.go
+++ b/main.go
@@ -5,7 +5,6 @@ import (
 	"expvar"
 	"flag"
 	"fmt"
-	"gopkg.in/natefinch/lumberjack.v2"
 	"io"
 	"io/ioutil"
 	"net"
@@ -18,6 +17,10 @@ import (
 	"sync"
 	"syscall"
 	"time"
+
+	"gopkg.in/natefinch/lumberjack.v2"
+
+	_ "net/http/pprof"
 
 	etcdcli "github.com/coreos/etcd/clientv3"
 	"github.com/coreos/etcd/embed"
@@ -49,7 +52,6 @@ import (
 	_ "github.com/signalfx/ondiskencoding"
 	_ "github.com/signalfx/tdigest"
 	_ "github.com/spaolacci/murmur3"
-	_ "net/http/pprof"
 	_ "stathat.com/c/consistent"
 )
 
@@ -200,6 +202,7 @@ func setupForwarders(ctx context.Context, tk timekeeper.TimeKeeper, loader *conf
 			Logger:       logCtx,
 			Now:          tk.Now,
 		}
+		// TODO ugh, this is busted, downstream loses the name here... not ideal, probably has delta rollover issues
 		dcount := &dpsink.Counter{
 			Logger:        limitedLogger,
 			DroppedReason: "downstream",

--- a/protocol/demultiplexer/demultiplexer_test.go
+++ b/protocol/demultiplexer/demultiplexer_test.go
@@ -3,9 +3,12 @@ package demultiplexer
 import (
 	"testing"
 
+	"github.com/signalfx/gateway/protocol/signalfx"
+
 	"time"
 
 	"context"
+
 	"github.com/signalfx/golib/datapoint"
 	"github.com/signalfx/golib/datapoint/dpsink"
 	"github.com/signalfx/golib/datapoint/dptest"
@@ -61,5 +64,13 @@ func TestNew(t *testing.T) {
 	assert.NoError(t, demux.AddDatapoints(context.Background(), []*datapoint.Datapoint{}))
 	assert.NoError(t, demux.AddEvents(context.Background(), []*event.Event{}))
 	assert.NoError(t, demux.AddSpans(context.Background(), []*trace.Span{}))
+
+	// prove we only send do the first one
+	sendTo3.Resize(3)
+	sendTo2.Resize(3)
+	assert.Equal(t, len(sendTo2.TracesChan), len(sendTo3.TracesChan))
+	assert.NoError(t, demux.AddSpans(context.WithValue(context.Background(), signalfx.Distributed, "1"), traces))
+	assert.NotEqual(t, len(sendTo2.TracesChan), len(sendTo3.TracesChan))
+
 	cancelFunc()
 }

--- a/protocol/signalfx/trace_zipkin_test.go
+++ b/protocol/signalfx/trace_zipkin_test.go
@@ -6,10 +6,12 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
-	"github.com/signalfx/gateway/protocol/signalfx/format"
+	signalfxformat "github.com/signalfx/gateway/protocol/signalfx/format"
+
 	"github.com/signalfx/golib/pointer"
 	"github.com/signalfx/golib/trace"
 	. "github.com/smartystreets/goconvey/convey"
@@ -196,10 +198,9 @@ func TestZipkinTraceDecoder(t *testing.T) {
 		},
 	}
 
-	req := http.Request{
-		Body: reqBody,
-	}
-	err := decoder.Read(context.Background(), &req)
+	req := httptest.NewRequest("get", "/v2/trace", reqBody)
+	req.Header.Add(string(Distributed), "1")
+	err := decoder.Read(context.Background(), req)
 
 	Convey("Valid spans should be sent even if some error", t, func() {
 		So(err.Error(), ShouldContainSubstring, "invalid binary annotation type")


### PR DESCRIPTION
- in a situation with the smart gateway redistirbuting spans, additional forwarders would
  end up forwarding some spans twice, once at the original smart gateway, then again
  on the destination of the re-distribution.

  To solve this we send a header on redistribution that is put into the context on the
  receiving gateway that will only demux that payload to the smart sampler.  This
  requires the smart sampler to be the first forwarder.